### PR TITLE
Disable provenance in Docker publish workflows

### DIFF
--- a/.github/workflows/publish-docker-full-amd64.yml
+++ b/.github/workflows/publish-docker-full-amd64.yml
@@ -34,6 +34,7 @@ jobs:
           file: Dockerfile
           push: true
           platforms: linux/amd64
+          provenance: false
           tags: |
             ghcr.io/${{ github.repository }}:${{ steps.version.outputs.VERSION }}-amd64
             ghcr.io/${{ github.repository }}:latest-amd64

--- a/.github/workflows/publish-docker-full-arm64.yml
+++ b/.github/workflows/publish-docker-full-arm64.yml
@@ -37,6 +37,7 @@ jobs:
           file: Dockerfile
           push: true
           platforms: linux/arm64
+          provenance: false
           tags: |
             ghcr.io/${{ github.repository }}:${{ steps.version.outputs.VERSION }}-arm64
             ghcr.io/${{ github.repository }}:latest-arm64

--- a/.github/workflows/publish-docker-proxy-amd64.yml
+++ b/.github/workflows/publish-docker-proxy-amd64.yml
@@ -34,6 +34,7 @@ jobs:
           file: Dockerfile.proxy_only
           push: true
           platforms: linux/amd64
+          provenance: false
           tags: |
             ghcr.io/${{ github.repository }}:${{ steps.version.outputs.VERSION }}-proxy-amd64
             ghcr.io/${{ github.repository }}:latest-proxy-amd64

--- a/.github/workflows/publish-docker-proxy-arm64.yml
+++ b/.github/workflows/publish-docker-proxy-arm64.yml
@@ -37,6 +37,7 @@ jobs:
           file: Dockerfile.proxy_only
           push: true
           platforms: linux/arm64
+          provenance: false
           tags: |
             ghcr.io/${{ github.repository }}:${{ steps.version.outputs.VERSION }}-proxy-arm64
             ghcr.io/${{ github.repository }}:latest-proxy-arm64


### PR DESCRIPTION
Set 'provenance: false' in all Docker publish GitHub Actions workflows for both amd64 and arm64 images. This change disables provenance generation during image builds.