### PR TITLE
Fix typo in math_verify package name

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -35,4 +35,4 @@ datasets
 mcp
 # MLX support for Apple Silicon optimization
 mlx-lm>=0.24.0; platform_machine=="arm64" and sys_platform=="darwin"
-math_verify
+math-verify


### PR DESCRIPTION
The real package path is https://pypi.org/project/math-verify. 
When I run `pipx install optillm` it does not install the `math-verify` package so the command `optillm` fails like this:

```
Traceback (most recent call last):
  File "/home/XXX/.local/bin/optillm", line 3, in <module>
    from optillm import main
  File "/home/XXX/.local/share/pipx/venvs/optillm/lib/python3.12/site-packages/optillm/__init__.py", line 5, in <module>
    from .server import (
  File "/home/XXX/.local/share/pipx/venvs/optillm/lib/python3.12/site-packages/optillm/server.py", line 34, in <module>
    from optillm.cepo.cepo import cepo, CepoConfig, init_cepo_config
  File "/home/XXX/.local/share/pipx/venvs/optillm/lib/python3.12/site-packages/optillm/cepo/cepo.py", line 6, in <module>
    import math_verify

ModuleNotFoundError: No module named 'math_verify'
```